### PR TITLE
Attempting to re-split out Email/SMS/Slack services

### DIFF
--- a/src/main/java/org/eaa690/aerie/config/ServiceConfig.java
+++ b/src/main/java/org/eaa690/aerie/config/ServiceConfig.java
@@ -26,11 +26,11 @@ import org.eaa690.aerie.constant.CommonConstants;
 import org.eaa690.aerie.constant.PropertyKeyConstants;
 import org.eaa690.aerie.exception.ResourceNotFoundException;
 import org.eaa690.aerie.model.WeatherProductRepository;
-import org.eaa690.aerie.service.CommunicationService;
 import org.eaa690.aerie.service.JotFormService;
 import org.eaa690.aerie.service.MailChimpService;
 import org.eaa690.aerie.service.PropertyService;
 import org.eaa690.aerie.service.RosterService;
+import org.eaa690.aerie.service.SlackService;
 import org.eaa690.aerie.service.TinyURLService;
 import org.eaa690.aerie.service.WeatherService;
 import org.eaa690.aerie.ssl.SSLUtilities;
@@ -214,18 +214,18 @@ public class ServiceConfig {
      * SlackSession.
      *
      * @param propertyService PropertyService
-     * @param communicationService SlackService
+     * @param slackService SlackService
      * @return SlackSession
      */
     @Bean
     public SlackSession slackSession(final PropertyService propertyService,
-                                     final CommunicationService communicationService) {
+                                     final SlackService slackService) {
         try {
             final SlackSession slackSession = SlackSessionFactory
                     .createWebSocketSlackSession(
                             propertyService.get(PropertyKeyConstants.SLACK_TOKEN_KEY).getValue());
             slackSession.connect();
-            slackSession.addMessagePostedListener(communicationService);
+            slackSession.addMessagePostedListener(slackService);
             return slackSession;
         } catch (IOException | ResourceNotFoundException e) {
             return null;

--- a/src/main/java/org/eaa690/aerie/service/CommunicationService.java
+++ b/src/main/java/org/eaa690/aerie/service/CommunicationService.java
@@ -16,58 +16,43 @@
 
 package org.eaa690.aerie.service;
 
-import java.io.IOException;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-import com.sendgrid.Method;
-import com.sendgrid.Request;
-import com.sendgrid.Response;
 import com.sendgrid.SendGrid;
-import com.sendgrid.helpers.mail.Mail;
-import com.sendgrid.helpers.mail.objects.Content;
-import com.sendgrid.helpers.mail.objects.Email;
-import com.sendgrid.helpers.mail.objects.Personalization;
 import com.ullink.slack.simpleslackapi.SlackSession;
-import com.ullink.slack.simpleslackapi.events.SlackMessagePosted;
-import com.ullink.slack.simpleslackapi.listeners.SlackMessagePostedListener;
+import lombok.Getter;
 import org.eaa690.aerie.communication.AcceptsEmailPredicate;
 import org.eaa690.aerie.communication.AcceptsSMSPredicate;
 import org.eaa690.aerie.communication.AcceptsSlackPredicate;
-import org.eaa690.aerie.constant.PropertyKeyConstants;
 import org.eaa690.aerie.exception.ResourceNotFoundException;
 import org.eaa690.aerie.model.Member;
 import org.eaa690.aerie.model.MemberRepository;
-import org.eaa690.aerie.model.MessageType;
 import org.eaa690.aerie.model.QueuedMessage;
 import org.eaa690.aerie.model.QueuedMessageRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
 
 /**
  * CommunicationService.
  */
-@Service
-public class CommunicationService implements SlackMessagePostedListener {
+@Getter
+public abstract class CommunicationService {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommunicationService.class);
 
     /**
      * SendGrid API.
      */
     @Autowired
     private SendGrid sendGrid;
-
-    /**
-     * Logger.
-     */
-    private static final Logger LOGGER = LoggerFactory.getLogger(CommunicationService.class);
 
     /**
      * PropertyService.
@@ -178,11 +163,7 @@ public class CommunicationService implements SlackMessagePostedListener {
      * @param queuedMessage QueuedMessage
      */
     public void queueMsg(final QueuedMessage queuedMessage) {
-        if (queuedMessage.getMessageType() == MessageType.Slack) {
-            sendSlackMessage(queuedMessage);
-        } else {
-            queuedMessageRepository.save(queuedMessage);
-        }
+        queuedMessageRepository.save(queuedMessage);
     }
 
     /**
@@ -197,48 +178,7 @@ public class CommunicationService implements SlackMessagePostedListener {
     /**
      * Looks for any messages in the send queue, and sends up to X (see configuration) messages per day.
      */
-    @Scheduled(cron = "0 0 10 * * *")
-    public void processQueue() {
-        final Optional<List<QueuedMessage>> allQueuedMessages = queuedMessageRepository.findAll();
-        if (allQueuedMessages.isPresent()) {
-            try {
-                allQueuedMessages
-                        .get()
-                        .stream()
-                        .limit(Long.parseLong(
-                                propertyService.get(PropertyKeyConstants.SEND_GRID_LIMIT).getValue()))
-                        .forEach(qe -> {
-                            sendSlackMessage(qe);
-                            sendSMSMessage(qe);
-                            sendEmailMessage(qe);
-                            queuedMessageRepository.delete(qe);
-                        });
-            } catch (ResourceNotFoundException e) {
-                LOGGER.error("Error", e);
-            }
-        }
-    }
-
-    /**
-     * Processes messages received by membership slack bot.
-     *
-     * @param event SlackMessagePosted
-     * @param session SlackSession
-     */
-    @Override
-    public void onEvent(final SlackMessagePosted event, final SlackSession session) {
-        // Ignore bot user messages
-        if (session.sessionPersona().getId().equals(event.getSender().getId())) {
-            return;
-        }
-        final String message = event.getMessageContent();
-        final String user = event.getUser().getUserName();
-        final String msg = String.format(
-                "Slack message received: user [%s]; message [%s]",
-                user,
-                message);
-        LOGGER.info(msg);
-    }
+    public abstract void processQueue();
 
     /**
      * Gets all Slack users.
@@ -260,7 +200,7 @@ public class CommunicationService implements SlackMessagePostedListener {
      * @param msgKey message key
      * @return message
      */
-    private String getSMSOrSlackMessage(final Member member, final String msgKey) {
+    protected String getSMSOrSlackMessage(final Member member, final String msgKey) {
         try {
             final String expiration;
             if (member.getExpiration() != null) {
@@ -283,204 +223,24 @@ public class CommunicationService implements SlackMessagePostedListener {
     }
 
     /**
-     * Sends a message via the Slack bot.
+     * Sends a message.
      *
      * @param queuedMessage QueuedMessage
      */
-    private void sendSlackMessage(final QueuedMessage queuedMessage) {
-        if (queuedMessage.getMessageType() == MessageType.Slack) {
-            Optional<Member> memberOpt = memberRepository.findById(queuedMessage.getMemberId());
-            if (memberOpt.isPresent() && acceptsSlackPredicate.test(memberOpt.get())) {
-                LOGGER.info(String.format("Sending Slack message [%s] to [%s]", queuedMessage.getBody(),
-                        queuedMessage.getRecipientAddress()));
-                slackSession.sendMessageToUser(slackSession.findUserByUserName(queuedMessage.getRecipientAddress()),
-                        queuedMessage.getBody(), null);
-            }
-        }
-    }
-
-    /**
-     * Sends an SMS message via SendGrid.
-     *
-     * @param queuedMessage QueuedMessage
-     */
-    private void sendSMSMessage(final QueuedMessage queuedMessage) {
-        if (queuedMessage.getMessageType() == MessageType.SMS) {
-            final Optional<Member> memberOpt = memberRepository.findById(queuedMessage.getMemberId());
-            if (memberOpt.isPresent()) {
-                final Member member = memberOpt.get();
-                if (acceptsSMSPredicate.test(member)) {
-                    queuedMessage.setRecipientAddress(String.format("%s@%s",
-                            queuedMessage.getRecipientAddress(),
-                            member.getCellPhoneProvider().getCellPhoneProviderEmailDomain()));
-                    sendEmailMessage(queuedMessage);
-                }
-            }
-        }
-    }
-
-    /**
-     * Sends an Email message via SendGrid.
-     *
-     * @param queuedMessage QueuedMessage
-     */
-    private void sendEmailMessage(final QueuedMessage queuedMessage) {
-        if (queuedMessage.getMessageType() == MessageType.Email) {
-            try {
-                final Optional<Member> memberOpt = memberRepository.findById(queuedMessage.getMemberId());
-                if (memberOpt.isPresent()) {
-                    final Member member = memberOpt.get();
-                    if (acceptsEmailPredicate.test(member)) {
-                        Email from = new Email(propertyService.get(PropertyKeyConstants.SEND_GRID_FROM_ADDRESS_KEY)
-                                .getValue());
-                        String subject = propertyService.get(queuedMessage.getSubjectKey()).getValue();
-                        Email to = new Email(queuedMessage.getRecipientAddress());
-                        if (Boolean.parseBoolean(
-                                propertyService.get(PropertyKeyConstants.EMAIL_TEST_MODE_ENABLED_KEY).getValue())) {
-                            to = new Email(propertyService.get(PropertyKeyConstants.EMAIL_TEST_MODE_RECIPIENT_KEY)
-                                    .getValue());
-                        }
-
-                        final Mail mail;
-                        if (queuedMessage.getTemplateIdKey() != null) {
-                            mail = new Mail();
-                            mail.setSubject(subject);
-                            mail.setTemplateId(propertyService.get(queuedMessage.getTemplateIdKey()).getValue());
-                            mail.addPersonalization(personalize(member, to));
-                            mail.setFrom(from);
-                        } else {
-                            mail = new Mail(from, subject, to, new Content("text/plain",
-                                    queuedMessage.getBody()));
-                        }
-
-                        final Request request = new Request();
-                        request.setMethod(Method.POST);
-                        request.setEndpoint("mail/send");
-                        request.setBody(mail.build());
-                        Response response = sendGrid.api(request);
-                        LOGGER.info(String.format("Response... statusCode [%s]; body [%s]; headers [%s]",
-                                response.getStatusCode(), response.getBody(), response.getHeaders()));
-                    }
-                }
-            } catch (IOException | ResourceNotFoundException ex) {
-                LOGGER.error(ex.getMessage());
-            }
-        }
-    }
-
-    /**
-     * Personalizes an email to the member.
-     *
-     * @param member Member
-     * @param to address
-     * @return Personalization
-     * @throws ResourceNotFoundException when property is not found
-     */
-    private Personalization personalize(final Member member, final Email to) throws ResourceNotFoundException {
-        final Personalization personalization = new Personalization();
-        personalization.addTo(to);
-        personalization.addBcc(new Email(propertyService.get(PropertyKeyConstants.EMAIL_BCC_KEY).getValue()));
-        personalization.addDynamicTemplateData("firstName", member.getFirstName());
-        personalization.addDynamicTemplateData("lastName", member.getLastName());
-        personalization.addDynamicTemplateData("url", jotFormService.buildRenewMembershipUrl(member));
-        if (member.getExpiration() == null) {
-            personalization.addDynamicTemplateData("expirationDate", ZonedDateTime.ofInstant(Instant.now(),
-                    ZoneId.systemDefault()).format(
-                    DateTimeFormatter.ofPattern("MMM d, yyyy")));
-        } else {
-            personalization.addDynamicTemplateData("expirationDate", ZonedDateTime.ofInstant(
-                    member.getExpiration().toInstant(),
-                    ZoneId.systemDefault()).format(
-                    DateTimeFormatter.ofPattern("MMM d, yyyy")));
-        }
-        return personalization;
-    }
+    public abstract void sendMessage(QueuedMessage queuedMessage);
 
     /**
      * Sends new member message.
      *
      * @param member Member
      */
-    public void sendNewMembershipMsg(final Member member) {
-        if (member != null && member.getSlack() != null && member.isSlackEnabled()) {
-            try {
-                final QueuedMessage queuedSlackMessage = new QueuedMessage();
-                queuedSlackMessage.setMemberId(member.getId());
-                queuedSlackMessage.setBody(getSMSOrSlackMessage(member, PropertyKeyConstants.SLACK_NEW_MEMBER_MSG_KEY));
-                queuedSlackMessage.setMessageType(MessageType.Slack);
-                queuedSlackMessage.setRecipientAddress(getSlackName(member));
-                queueMsg(queuedSlackMessage);
-
-                final QueuedMessage queuedSMSMessage = new QueuedMessage();
-                queuedSMSMessage.setMemberId(member.getId());
-                queuedSMSMessage.setBody(getSMSOrSlackMessage(member, PropertyKeyConstants.SMS_NEW_MEMBER_MSG_KEY));
-                queuedSMSMessage.setMessageType(MessageType.SMS);
-                queuedSMSMessage.setRecipientAddress(member.getCellPhone());
-                queueMsg(queuedSMSMessage);
-
-                final QueuedMessage queuedEmailMessage = new QueuedMessage();
-                queuedEmailMessage.setMemberId(member.getId());
-                queuedEmailMessage.setSubjectKey(PropertyKeyConstants.SEND_GRID_NEW_MEMBERSHIP_EMAIL_SUBJECT_KEY);
-                queuedEmailMessage.setTemplateIdKey(PropertyKeyConstants.SEND_GRID_NEW_MEMBERSHIP_EMAIL_TEMPLATE_ID);
-                queuedEmailMessage.setRecipientAddress(member.getEmail());
-                queuedEmailMessage.setMessageType(MessageType.Email);
-                queueMsg(queuedEmailMessage);
-            } catch (ResourceNotFoundException ex) {
-                LOGGER.error(ex.getMessage());
-            }
-        }
-    }
+    public abstract void sendNewMembershipMsg(Member member);
 
     /**
      * Sends membership renewal message.
      *
      * @param member Member
      */
-    public void sendRenewMembershipMsg(final Member member) {
-        if (member != null && member.getSlack() != null && member.isSlackEnabled()) {
-            try {
-                final QueuedMessage queuedSlackMessage = new QueuedMessage();
-                queuedSlackMessage.setMemberId(member.getId());
-                queuedSlackMessage.setBody(getSMSOrSlackMessage(member,
-                        PropertyKeyConstants.SLACK_RENEW_MEMBER_MSG_KEY));
-                queuedSlackMessage.setMessageType(MessageType.Slack);
-                queuedSlackMessage.setRecipientAddress(getSlackName(member));
-                queueMsg(queuedSlackMessage);
-
-                final QueuedMessage queuedSMSMessage = new QueuedMessage();
-                queuedSMSMessage.setMemberId(member.getId());
-                queuedSMSMessage.setBody(getSMSOrSlackMessage(member, PropertyKeyConstants.SMS_RENEW_MEMBER_MSG_KEY));
-                queuedSMSMessage.setMessageType(MessageType.SMS);
-                queuedSMSMessage.setRecipientAddress(member.getCellPhone());
-                queueMsg(queuedSMSMessage);
-
-                final QueuedMessage queuedEmailMessage = new QueuedMessage();
-                queuedEmailMessage.setMemberId(member.getId());
-                queuedEmailMessage.setSubjectKey(PropertyKeyConstants.SEND_GRID_NEW_MEMBERSHIP_EMAIL_SUBJECT_KEY);
-                queuedEmailMessage.setTemplateIdKey(PropertyKeyConstants.SEND_GRID_NEW_MEMBERSHIP_EMAIL_TEMPLATE_ID);
-                queuedEmailMessage.setRecipientAddress(member.getEmail());
-                queuedEmailMessage.setMessageType(MessageType.Email);
-                queueMsg(queuedEmailMessage);
-            } catch (ResourceNotFoundException ex) {
-                LOGGER.error(ex.getMessage());
-            }
-        }
-    }
-
-    /**
-     * Gets Slack name, or overridden value, if in test mode.
-     *
-     * @param member Member
-     * @return Slack name
-     * @throws ResourceNotFoundException if properties are not found
-     */
-    private String getSlackName(final Member member) throws ResourceNotFoundException {
-        String to = member.getSlack();
-        if (Boolean.parseBoolean(
-                propertyService.get(PropertyKeyConstants.SLACK_TEST_MODE_ENABLED_KEY).getValue())) {
-            to = propertyService.get(PropertyKeyConstants.SLACK_TEST_MODE_RECIPIENT_KEY).getValue();
-        }
-        return to;
-    }
+    public abstract void sendRenewMembershipMsg(Member member);
 
 }

--- a/src/main/java/org/eaa690/aerie/service/EmailService.java
+++ b/src/main/java/org/eaa690/aerie/service/EmailService.java
@@ -1,0 +1,194 @@
+/*
+ *  Copyright (C) 2021 Gwinnett County Experimental Aircraft Association
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.eaa690.aerie.service;
+
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import com.sendgrid.helpers.mail.objects.Personalization;
+import org.eaa690.aerie.constant.PropertyKeyConstants;
+import org.eaa690.aerie.exception.ResourceNotFoundException;
+import org.eaa690.aerie.model.Member;
+import org.eaa690.aerie.model.MessageType;
+import org.eaa690.aerie.model.QueuedMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * EmailService.
+ */
+@Service
+public class EmailService extends CommunicationService {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmailService.class);
+
+    /**
+     * Looks for any messages in the send queue, and sends up to X (see configuration) messages per day.
+     */
+    @Override
+    @Scheduled(cron = "0 0 10 * * *")
+    public void processQueue() {
+        final Optional<List<QueuedMessage>> allQueuedMessages = getQueuedMessageRepository().findAll();
+        if (allQueuedMessages.isPresent()) {
+            try {
+                allQueuedMessages
+                        .get()
+                        .stream()
+                        .filter(qm -> qm.getMessageType() == MessageType.Email)
+                        .limit(Long.parseLong(
+                                getPropertyService().get(PropertyKeyConstants.SEND_GRID_LIMIT).getValue()))
+                        .forEach(qe -> {
+                            sendMessage(qe);
+                            getQueuedMessageRepository().delete(qe);
+                        });
+            } catch (ResourceNotFoundException e) {
+                LOGGER.error("Error", e);
+            }
+        }
+    }
+
+    /**
+     * Sends an Email message via SendGrid.
+     *
+     * @param queuedMessage QueuedMessage
+     */
+    @Override
+    public void sendMessage(final QueuedMessage queuedMessage) {
+        if (queuedMessage.getMessageType() == MessageType.Email) {
+            try {
+                final Optional<Member> memberOpt = getMemberRepository().findById(queuedMessage.getMemberId());
+                if (memberOpt.isPresent()) {
+                    final Member member = memberOpt.get();
+                    if (getAcceptsEmailPredicate().test(member)) {
+                        Email from = new Email(getPropertyService().get(PropertyKeyConstants.SEND_GRID_FROM_ADDRESS_KEY)
+                                .getValue());
+                        String subject = getPropertyService().get(queuedMessage.getSubjectKey()).getValue();
+                        Email to = new Email(queuedMessage.getRecipientAddress());
+                        if (Boolean.parseBoolean(getPropertyService()
+                                .get(PropertyKeyConstants.EMAIL_TEST_MODE_ENABLED_KEY).getValue())) {
+                            to = new Email(getPropertyService().get(PropertyKeyConstants.EMAIL_TEST_MODE_RECIPIENT_KEY)
+                                    .getValue());
+                        }
+
+                        final Mail mail;
+                        if (queuedMessage.getTemplateIdKey() != null) {
+                            mail = new Mail();
+                            mail.setSubject(subject);
+                            mail.setTemplateId(getPropertyService().get(queuedMessage.getTemplateIdKey()).getValue());
+                            mail.addPersonalization(personalize(member, to));
+                            mail.setFrom(from);
+                        } else {
+                            mail = new Mail(from, subject, to, new Content("text/plain",
+                                    queuedMessage.getBody()));
+                        }
+
+                        final Request request = new Request();
+                        request.setMethod(Method.POST);
+                        request.setEndpoint("mail/send");
+                        request.setBody(mail.build());
+                        Response response = getSendGrid().api(request);
+                        LOGGER.info(String.format("Response... statusCode [%s]; body [%s]; headers [%s]",
+                                response.getStatusCode(), response.getBody(), response.getHeaders()));
+                    }
+                }
+            } catch (IOException | ResourceNotFoundException ex) {
+                LOGGER.error(ex.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Sends new member message.
+     *
+     * @param member Member
+     */
+    @Override
+    public void sendNewMembershipMsg(final Member member) {
+        if (getAcceptsEmailPredicate().test(member)) {
+            final QueuedMessage queuedEmailMessage = new QueuedMessage();
+            queuedEmailMessage.setMemberId(member.getId());
+            queuedEmailMessage.setSubjectKey(PropertyKeyConstants.SEND_GRID_NEW_MEMBERSHIP_EMAIL_SUBJECT_KEY);
+            queuedEmailMessage.setTemplateIdKey(PropertyKeyConstants.SEND_GRID_NEW_MEMBERSHIP_EMAIL_TEMPLATE_ID);
+            queuedEmailMessage.setRecipientAddress(member.getEmail());
+            queuedEmailMessage.setMessageType(MessageType.Email);
+            queueMsg(queuedEmailMessage);
+        }
+    }
+
+    /**
+     * Sends membership renewal message.
+     *
+     * @param member Member
+     */
+    @Override
+    public void sendRenewMembershipMsg(final Member member) {
+        if (getAcceptsEmailPredicate().test(member)) {
+            final QueuedMessage queuedEmailMessage = new QueuedMessage();
+            queuedEmailMessage.setMemberId(member.getId());
+            queuedEmailMessage.setSubjectKey(PropertyKeyConstants.SEND_GRID_NEW_MEMBERSHIP_EMAIL_SUBJECT_KEY);
+            queuedEmailMessage.setTemplateIdKey(PropertyKeyConstants.SEND_GRID_NEW_MEMBERSHIP_EMAIL_TEMPLATE_ID);
+            queuedEmailMessage.setRecipientAddress(member.getEmail());
+            queuedEmailMessage.setMessageType(MessageType.Email);
+            queueMsg(queuedEmailMessage);
+        }
+    }
+
+    /**
+     * Personalizes an email to the member.
+     *
+     * @param member Member
+     * @param to address
+     * @return Personalization
+     * @throws ResourceNotFoundException when property is not found
+     */
+    private Personalization personalize(final Member member, final Email to) throws ResourceNotFoundException {
+        final Personalization personalization = new Personalization();
+        personalization.addTo(to);
+        personalization.addBcc(new Email(getPropertyService().get(PropertyKeyConstants.EMAIL_BCC_KEY).getValue()));
+        personalization.addDynamicTemplateData("firstName", member.getFirstName());
+        personalization.addDynamicTemplateData("lastName", member.getLastName());
+        personalization.addDynamicTemplateData("url", getJotFormService().buildRenewMembershipUrl(member));
+        if (member.getExpiration() == null) {
+            personalization.addDynamicTemplateData("expirationDate", ZonedDateTime.ofInstant(Instant.now(),
+                    ZoneId.systemDefault()).format(
+                    DateTimeFormatter.ofPattern("MMM d, yyyy")));
+        } else {
+            personalization.addDynamicTemplateData("expirationDate", ZonedDateTime.ofInstant(
+                    member.getExpiration().toInstant(),
+                    ZoneId.systemDefault()).format(
+                    DateTimeFormatter.ofPattern("MMM d, yyyy")));
+        }
+        return personalization;
+    }
+
+}

--- a/src/main/java/org/eaa690/aerie/service/RosterService.java
+++ b/src/main/java/org/eaa690/aerie/service/RosterService.java
@@ -65,7 +65,19 @@ public class RosterService {
      * EmailService.
      */
     @Autowired
-    private CommunicationService communicationService;
+    private EmailService emailService;
+
+    /**
+     * SMSService.
+     */
+    @Autowired
+    private SMSService smsService;
+
+    /**
+     * SlackService.
+     */
+    @Autowired
+    private SlackService slackService;
 
     /**
      * MemberRepository.
@@ -97,8 +109,30 @@ public class RosterService {
      * @param value EmailService
      */
     @Autowired
-    public void setCommunicationService(final CommunicationService value) {
-        communicationService = value;
+    public void setEmailService(final EmailService value) {
+        emailService = value;
+    }
+
+    /**
+     * Sets SMSService.
+     * Note: mostly used for unit test mocks
+     *
+     * @param value SMSService
+     */
+    @Autowired
+    public void setSMSService(final SMSService value) {
+        smsService = value;
+    }
+
+    /**
+     * Sets SlackService.
+     * Note: mostly used for unit test mocks
+     *
+     * @param value SlackService
+     */
+    @Autowired
+    public void setSlackService(final SlackService value) {
+        slackService = value;
     }
 
     /**
@@ -173,15 +207,21 @@ public class RosterService {
                                                         DateTimeFormatter.ofPattern("yyyy-MM-dd"));
                                 if (expirationDate.equals(
                                         getFutureDateStr(PropertyKeyConstants.MEMBERSHIP_RENEWAL_FIRST_MSG_DAYS_KEY))) {
-                                    communicationService.sendRenewMembershipMsg(member);
+                                    emailService.sendRenewMembershipMsg(member);
+                                    smsService.sendRenewMembershipMsg(member);
+                                    slackService.sendRenewMembershipMsg(member);
                                 }
                                 if (expirationDate.equals(getFutureDateStr(
                                                 PropertyKeyConstants.MEMBERSHIP_RENEWAL_SECOND_MSG_DAYS_KEY))) {
-                                    communicationService.sendRenewMembershipMsg(member);
+                                    emailService.sendRenewMembershipMsg(member);
+                                    smsService.sendRenewMembershipMsg(member);
+                                    slackService.sendRenewMembershipMsg(member);
                                 }
                                 if (expirationDate.equals(
                                         getFutureDateStr(PropertyKeyConstants.MEMBERSHIP_RENEWAL_THIRD_MSG_DAYS_KEY))) {
-                                    communicationService.sendRenewMembershipMsg(member);
+                                    emailService.sendRenewMembershipMsg(member);
+                                    smsService.sendRenewMembershipMsg(member);
+                                    slackService.sendRenewMembershipMsg(member);
                                 }
                                 if (expirationDate.equals(ZonedDateTime.ofInstant(Instant.now(),
                                         ZoneId.systemDefault()).format(

--- a/src/main/java/org/eaa690/aerie/service/SMSService.java
+++ b/src/main/java/org/eaa690/aerie/service/SMSService.java
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (C) 2021 Gwinnett County Experimental Aircraft Association
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.eaa690.aerie.service;
+
+import org.eaa690.aerie.constant.PropertyKeyConstants;
+import org.eaa690.aerie.exception.ResourceNotFoundException;
+import org.eaa690.aerie.model.Member;
+import org.eaa690.aerie.model.MessageType;
+import org.eaa690.aerie.model.QueuedMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * SMSService.
+ */
+@Service
+public class SMSService extends CommunicationService {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SMSService.class);
+
+    /**
+     * EmailService.
+     */
+    @Autowired
+    private EmailService emailService;
+
+    /**
+     * Sets EmailService.
+     * Note: mostly used for unit test mocks
+     *
+     * @param value EmailService
+     */
+    @Autowired
+    public void setEmailService(final EmailService value) {
+        emailService = value;
+    }
+
+    /**
+     * Looks for any messages in the send queue, and sends up to X (see configuration) messages per day.
+     */
+    @Override
+    @Scheduled(cron = "0 0 10 * * *")
+    public void processQueue() {
+        final Optional<List<QueuedMessage>> allQueuedMessages = getQueuedMessageRepository().findAll();
+        if (allQueuedMessages.isPresent()) {
+            try {
+                allQueuedMessages
+                        .get()
+                        .stream()
+                        .filter(qm -> qm.getMessageType() == MessageType.SMS)
+                        .limit(Long.parseLong(
+                                getPropertyService().get(PropertyKeyConstants.SEND_GRID_LIMIT).getValue()))
+                        .forEach(qe -> {
+                            sendMessage(qe);
+                            getQueuedMessageRepository().delete(qe);
+                        });
+            } catch (ResourceNotFoundException e) {
+                LOGGER.error("Error", e);
+            }
+        }
+    }
+
+    /**
+     * Sends an SMS message via SendGrid.
+     *
+     * @param queuedMessage QueuedMessage
+     */
+    @Override
+    public void sendMessage(final QueuedMessage queuedMessage) {
+        if (queuedMessage.getMessageType() == MessageType.SMS) {
+            final Optional<Member> memberOpt = getMemberRepository().findById(queuedMessage.getMemberId());
+            if (memberOpt.isPresent()) {
+                final Member member = memberOpt.get();
+                if (getAcceptsSMSPredicate().test(member)) {
+                    queuedMessage.setRecipientAddress(String.format("%s@%s",
+                            queuedMessage.getRecipientAddress(),
+                            member.getCellPhoneProvider().getCellPhoneProviderEmailDomain()));
+                    emailService.sendMessage(queuedMessage);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sends new member message.
+     *
+     * @param member Member
+     */
+    @Override
+    public void sendNewMembershipMsg(final Member member) {
+        if (member != null && member.getSlack() != null && member.isSlackEnabled()) {
+            final QueuedMessage queuedSMSMessage = new QueuedMessage();
+            queuedSMSMessage.setMemberId(member.getId());
+            queuedSMSMessage.setBody(getSMSOrSlackMessage(member, PropertyKeyConstants.SMS_NEW_MEMBER_MSG_KEY));
+            queuedSMSMessage.setMessageType(MessageType.SMS);
+            queuedSMSMessage.setRecipientAddress(member.getCellPhone());
+            queueMsg(queuedSMSMessage);
+        }
+    }
+
+    /**
+     * Sends membership renewal message.
+     *
+     * @param member Member
+     */
+    @Override
+    public void sendRenewMembershipMsg(final Member member) {
+        if (member != null && member.getSlack() != null && member.isSlackEnabled()) {
+            final QueuedMessage queuedSMSMessage = new QueuedMessage();
+            queuedSMSMessage.setMemberId(member.getId());
+            queuedSMSMessage.setBody(getSMSOrSlackMessage(member, PropertyKeyConstants.SMS_RENEW_MEMBER_MSG_KEY));
+            queuedSMSMessage.setMessageType(MessageType.SMS);
+            queuedSMSMessage.setRecipientAddress(member.getCellPhone());
+            queueMsg(queuedSMSMessage);
+        }
+    }
+
+}

--- a/src/main/java/org/eaa690/aerie/service/SlackService.java
+++ b/src/main/java/org/eaa690/aerie/service/SlackService.java
@@ -1,0 +1,184 @@
+/*
+ *  Copyright (C) 2021 Gwinnett County Experimental Aircraft Association
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.eaa690.aerie.service;
+
+import com.ullink.slack.simpleslackapi.SlackSession;
+import com.ullink.slack.simpleslackapi.events.SlackMessagePosted;
+import com.ullink.slack.simpleslackapi.listeners.SlackMessagePostedListener;
+import org.eaa690.aerie.constant.PropertyKeyConstants;
+import org.eaa690.aerie.exception.ResourceNotFoundException;
+import org.eaa690.aerie.model.Member;
+import org.eaa690.aerie.model.MessageType;
+import org.eaa690.aerie.model.QueuedMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * SlackService.
+ */
+@Service("aerieSlackService")
+public class SlackService extends CommunicationService implements SlackMessagePostedListener {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SlackService.class);
+
+    /**
+     * Looks for any messages in the send queue, and sends up to X (see configuration) messages per day.
+     */
+    @Override
+    @Scheduled(cron = "0 0 10 * * *")
+    public void processQueue() {
+        final Optional<List<QueuedMessage>> allQueuedMessages = getQueuedMessageRepository().findAll();
+        if (allQueuedMessages.isPresent()) {
+            try {
+                allQueuedMessages
+                        .get()
+                        .stream()
+                        .filter(qm -> qm.getMessageType() == MessageType.Slack)
+                        .limit(Long.parseLong(
+                                getPropertyService().get(PropertyKeyConstants.SEND_GRID_LIMIT).getValue()))
+                        .forEach(qe -> {
+                            sendMessage(qe);
+                            getQueuedMessageRepository().delete(qe);
+                        });
+            } catch (ResourceNotFoundException e) {
+                LOGGER.error("Error", e);
+            }
+        }
+    }
+
+    /**
+     * Processes messages received by membership slack bot.
+     *
+     * @param event SlackMessagePosted
+     * @param session SlackSession
+     */
+    @Override
+    public void onEvent(final SlackMessagePosted event, final SlackSession session) {
+        // Ignore bot user messages
+        if (session.sessionPersona().getId().equals(event.getSender().getId())) {
+            return;
+        }
+        final String message = event.getMessageContent();
+        final String user = event.getUser().getUserName();
+        final String msg = String.format(
+                "Slack message received: user [%s]; message [%s]",
+                user,
+                message);
+        LOGGER.info(msg);
+    }
+
+    /**
+     * Gets all Slack users.
+     *
+     * @return list of users
+     */
+    public List<String> allSlackUsers() {
+        final List<String> users = new ArrayList<>();
+        getSlackSession()
+                .getUsers()
+                .forEach(user -> users.add(user.getRealName() + "|" + user.getUserName()));
+        return users;
+    }
+
+    /**
+     * Sends a message via the Slack bot.
+     *
+     * @param queuedMessage QueuedMessage
+     */
+    @Override
+    public void sendMessage(final QueuedMessage queuedMessage) {
+        if (queuedMessage.getMessageType() == MessageType.Slack) {
+            Optional<Member> memberOpt = getMemberRepository().findById(queuedMessage.getMemberId());
+            if (memberOpt.isPresent() && getAcceptsSlackPredicate().test(memberOpt.get())) {
+                LOGGER.info(String.format("Sending Slack message [%s] to [%s]", queuedMessage.getBody(),
+                        queuedMessage.getRecipientAddress()));
+                getSlackSession().sendMessageToUser(
+                        getSlackSession().findUserByUserName(queuedMessage.getRecipientAddress()),
+                        queuedMessage.getBody(), null);
+            }
+        }
+    }
+
+    /**
+     * Sends new member message.
+     *
+     * @param member Member
+     */
+    @Override
+    public void sendNewMembershipMsg(final Member member) {
+        if (member != null && member.getSlack() != null && member.isSlackEnabled()) {
+            try {
+                final QueuedMessage queuedSlackMessage = new QueuedMessage();
+                queuedSlackMessage.setMemberId(member.getId());
+                queuedSlackMessage.setBody(getSMSOrSlackMessage(member, PropertyKeyConstants.SLACK_NEW_MEMBER_MSG_KEY));
+                queuedSlackMessage.setMessageType(MessageType.Slack);
+                queuedSlackMessage.setRecipientAddress(getSlackName(member));
+                queueMsg(queuedSlackMessage);
+            } catch (ResourceNotFoundException ex) {
+                LOGGER.error(ex.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Sends membership renewal message.
+     *
+     * @param member Member
+     */
+    @Override
+    public void sendRenewMembershipMsg(final Member member) {
+        if (member != null && member.getSlack() != null && member.isSlackEnabled()) {
+            try {
+                final QueuedMessage queuedSlackMessage = new QueuedMessage();
+                queuedSlackMessage.setMemberId(member.getId());
+                queuedSlackMessage.setBody(getSMSOrSlackMessage(member,
+                        PropertyKeyConstants.SLACK_RENEW_MEMBER_MSG_KEY));
+                queuedSlackMessage.setMessageType(MessageType.Slack);
+                queuedSlackMessage.setRecipientAddress(getSlackName(member));
+                queueMsg(queuedSlackMessage);
+            } catch (ResourceNotFoundException ex) {
+                LOGGER.error(ex.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Gets Slack name, or overridden value, if in test mode.
+     *
+     * @param member Member
+     * @return Slack name
+     * @throws ResourceNotFoundException if properties are not found
+     */
+    private String getSlackName(final Member member) throws ResourceNotFoundException {
+        String to = member.getSlack();
+        if (Boolean.parseBoolean(
+                getPropertyService().get(PropertyKeyConstants.SLACK_TEST_MODE_ENABLED_KEY).getValue())) {
+            to = getPropertyService().get(PropertyKeyConstants.SLACK_TEST_MODE_RECIPIENT_KEY).getValue();
+        }
+        return to;
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,10 +17,10 @@
 spring:
   datasource:
     username: aerie
-    password: ${AERIE_DB_PASS}
-    url: jdbc:mysql://localhost:3306/aerie?serverTimezone=America/New_York
+    password: aerie
+    url: jdbc:mysql://aerie-mysql:33061/aerie?serverTimezone=America/New_York
   jpa:
     database-platform: org.hibernate.dialect.MySQL57Dialect
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
…using CommunicationsService as a base

Note: this code does not work yet due to:

The dependencies of some of the beans in the application context form a cycle:

   adminController
      ↓
   rosterService (field private org.eaa690.aerie.service.EmailService org.eaa690.aerie.service.RosterService.emailService)
      ↓
   emailService (field private com.ullink.slack.simpleslackapi.SlackSession org.eaa690.aerie.service.CommunicationService.slackSession)
┌─────┐
|  slackSession defined in class path resource [org/eaa690/aerie/config/ServiceConfig.class]
↑     ↓
|  aerieSlackService (field private com.ullink.slack.simpleslackapi.SlackSession org.eaa690.aerie.service.CommunicationService.slackSession)
└─────┘

